### PR TITLE
Small fixes found while starting rOpenSci review

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,28 +4,32 @@ Version: 0.0.0.9000
 Authors@R: 
     person("Renata", "Diaz", , "renata.diaz@weecology.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-0803-4734"))
-Date: 2023-02-27
-Description: Generate estimated body size distributions for populations or communities of birds, given either species ID or species' mean body size. Designed to work naturally with the North American Breeding Bird Survey, or with any dataset of bird species, abundance, and/or mean size data.   
+Description: Generate estimated body size distributions for populations or
+    communities of birds, given either species ID or species' mean body
+    size. Designed to work naturally with the North American Breeding Bird
+    Survey, or with any dataset of bird species, abundance, and/or mean
+    size data.
 License: MIT + file LICENSE
 URL: https://github.com/diazrenata/birdsize
 BugReports: https://github.com/diazrenata/birdsize/issues
-Encoding: UTF-8
-LazyData: true
-Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+Depends: 
+    R (>= 2.10)
+Imports: 
+    dplyr,
+    magrittr,
+    purrr,
+    rlang,
+    stats
 Suggests: 
     covr,
     ggplot2,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)
+VignetteBuilder: 
+    knitr
 Config/testthat/edition: 3
-Depends: 
-    R (>= 2.10)
-Imports: 
-    rlang,
-    dplyr,
-    magrittr,
-    purrr,
-    stats
-VignetteBuilder: knitr
+Encoding: UTF-8
+LazyData: true
+Roxygen: list(markdown = TRUE)
+RoxygenNote: 7.2.1

--- a/R/bbs_species_list_functions.R
+++ b/R/bbs_species_list_functions.R
@@ -9,7 +9,7 @@
 #'
 #'
 is_unidentified <- function(names) {
-  names[names == "auratus auratus x auratus cafer"] = "auratus auratus"
+  names[names == "auratus auratus x auratus cafer"] <- "auratus auratus"
   grepl("sp\\.| x |\\/", names)
 }
 

--- a/R/species_data_functions.R
+++ b/R/species_data_functions.R
@@ -90,7 +90,7 @@ clean_sp_size_data <- function(raw_size_data) {
   sp_clean <- dplyr::filter(sp_clean, is.na(.data$not_in_dunning)) %>%
     dplyr::mutate(added_flag = NA)
 
-  for (i in 1:nrow(name_change)) {
+  for (i in seq_len(nrow(name_change))) {
     if (!is.na(name_change$close_subspecies[i])) {
       matched_rows <- dplyr::filter(
         sp_clean,
@@ -132,7 +132,7 @@ clean_sp_size_data <- function(raw_size_data) {
 add_estimated_sds <- function(clean_size_data, sd_pars) {
   clean_size_data$estimated_sd <- FALSE
 
-  for (i in 1:nrow(clean_size_data)) {
+  for (i in seq_len(nrow(clean_size_data))) {
     if (is.na(clean_size_data$sd[i])) {
       clean_size_data$estimated_sd[i] <- TRUE
       clean_size_data$sd[i] <- species_estimate_sd(clean_size_data$mass[i], pars = sd_pars)
@@ -164,7 +164,7 @@ get_sp_mean_size <- function(sd_dat) {
     dplyr::group_by(.data$aou, .data$genus, .data$species) %>%
     dplyr::summarize(
       mean_mass = mean(.data$mass),
-      mean_sd = mean(.data$sd, na.rm = F),
+      mean_sd = mean(.data$sd, na.rm = FALSE),
       contains_estimates = any(.data$estimated_sd)
     ) %>%
     dplyr::ungroup() %>%

--- a/R/summary_functions.R
+++ b/R/summary_functions.R
@@ -69,7 +69,7 @@ community_summarize <- function(community, level = c("year", "species", "species
 
   # Grouping
 
-  level = match.arg(level, several.ok = F)
+  level <- match.arg(level, several.ok = FALSE)
 
 
   id_vars <- switch(level,

--- a/README.md
+++ b/README.md
@@ -23,13 +23,7 @@ For most users, the [community](https://diazrenata.github.io/birdsize/articles/c
 
 ## Installation
 
-To install the in-development version, use `remotes` or `devtools`:
-
-```
-remotes::install_github('diazrenata/birdsize')
-```
-
-or 
+To install the in-development version, use `devtools`:
 
 ```
 devtools::install_github('diazrenata/birdsize')


### PR DESCRIPTION
PR for a few small changes as I take a first look prior to review for rOpenSci at https://github.com/ropensci/software-review/issues/577

- cleaned up DESCRIPTION using `desc::desc_normalize()`
- remove `remotes::install_github()` instructions from README, redundant since you have `devtools::install_github()` instructions
- replaced two uses of `=` for assignment with `<-` for consistency
- replaced `T/F` with `TRUE/FALSE` in two places
- replaced `1:nrow()` with `seq_len(nrow())` in two places